### PR TITLE
TIK-002 Adds SECRET_KEY to environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ dmypy.json
 .coverage
 .tox
 nosetests.xml
+
+# environment variable management
+.envrc

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     build: .
     command: python manage.py runserver 0.0.0.0:8000
     container_name: qaas_web
+    environment:
+      - DJANGO_SECRET_KEY
     volumes:
       - .:/code
     ports:

--- a/operqaas/settings.py
+++ b/operqaas/settings.py
@@ -10,6 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/4.1/ref/settings/
 """
 
+import os
 from pathlib import Path
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -19,8 +20,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.1/howto/deployment/checklist/
 
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = "django-insecure-m%=nn2sgzd=vvxv4$484-5#=ljkoblj$(fxk#to%_)(qqq#vr4"
+SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
# TIK-002

## This PR

To set environment variables, I have them in `.envrc` file (which can be set) both on your local env or production. The `git` repo is configured to ignore this file. Caveats:

* it has to be located in the project's root directory
* it has to be loaded every time you enter the directory as all Django commands below expect the env variables in it to be loaded
  * you can use an automated tool you like for this, I am biased towards [direnv](https://direnv.net/)

The mandatory variable that needs to be set is `DJANGO_SECRET_KEY`. Example set up on my local env:

```
$ cat .envrc 
export DJANGO_SECRET_KEY='django-insecure-m%=nn2sgzd=vvxv4$484-5#=ljkoblj$(fxk#to%_)(qqq#vr4'
```